### PR TITLE
Simplified diff report for contracts validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ tmp
 dist/
 notary.iml
 coverage.lcov
+projects.yml

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "ajv": "^5.0.1",
     "child-process-promise": "^2.2.1",
+    "deep-diff": "^0.3.8",
     "express": "^4.14.0",
     "express-handlebars": "^3.0.0",
     "express-winston": "^2.0.0",

--- a/src/contracts/integrations/rest/validator.js
+++ b/src/contracts/integrations/rest/validator.js
@@ -1,38 +1,42 @@
 import util from 'util';
+import { diff } from 'deep-diff';
 
 import _ from 'lodash';
 import { VError } from 'verror';
 
+const inspect = o => {
+  return util.inspect(o, false, null);
+};
+
 export default {
   async isSubset(producerSwagger, consumerSwagger) {
-    const inspect = o => {
-      return util.inspect(o, false, null);
-    };
     const validateBasePath = (producerSwagger, consumerSwagger) => {
       if (producerSwagger.basePath !== consumerSwagger.basePath) {
         throw new VError(
-          `Expectation broken: ${inspect(producerSwagger.basePath)} != ${inspect(
-            consumerSwagger.basePath
-          )}`
+          `Expectation broken: \n ` +
+            `- Expected: basePath --> ${consumerSwagger.basePath}` +
+            `- Promised: basePath --> ${producerSwagger.basePath}`
         );
       }
     };
     const validateSchemes = (producerSwagger, consumerSwagger) => {
-      if (!_.isMatch(producerSwagger.schemes, consumerSwagger.schemes)) {
-        throw new VError(
-          `Expectation broken: \n\n ${inspect(
-            consumerSwagger.schemes
-          )} \n\nis not a subset of: \n\n${inspect(producerSwagger.schemes)}\n`
-        );
+      const { isSubset, report } = this.subsetReport(
+        producerSwagger.schemes,
+        consumerSwagger.schemes,
+        'schemes'
+      );
+      if (!isSubset) {
+        throw new VError(`Expectation broken: \n ${report}`);
       }
     };
     const validatePaths = (producerSwagger, consumerSwagger) => {
-      if (!_.isMatch(producerSwagger.paths, consumerSwagger.paths)) {
-        throw new VError(
-          `Expectation broken: \n\n ${inspect(
-            consumerSwagger.paths
-          )} \n\nis not a subset of: \n\n${inspect(producerSwagger.paths)}`
-        );
+      const { isSubset, report } = this.subsetReport(
+        producerSwagger.paths,
+        consumerSwagger.paths,
+        'paths'
+      );
+      if (!isSubset) {
+        throw new VError(`Expectation broken: \n${report}`);
       }
     };
     const validateResponses = () => {};
@@ -42,5 +46,66 @@ export default {
     validateSchemes(producerSwagger, consumerSwagger);
     validatePaths(producerSwagger, consumerSwagger);
     validateResponses(producerSwagger, consumerSwagger);
+  },
+
+  /*
+   * Checks if rhs is a subset of lhs or not while generating a report.
+   *
+   * @return { isSubset: boolean, differences: array, report: string }
+   */
+  subsetReport(lhs, rhs, reportPrefix = '') {
+    if (reportPrefix !== '') {
+      reportPrefix = `${reportPrefix} -->`;
+    }
+
+    if (lhs === undefined) {
+      lhs = [];
+    }
+    if (rhs === undefined) {
+      rhs = [];
+    }
+
+    let differences = diff(lhs, rhs);
+
+    if (differences) {
+      differences = differences
+        // we don't care if the rhs is missing a field from lhs, it only needs to be a sub-set
+        .filter(d => {
+          return d.kind !== 'D' || (d.kind === 'A' && d.item.kind === 'D');
+        });
+    }
+
+    if (differences === undefined || differences.length === 0) {
+      return { isSubset: true, differences: [], report: '' };
+    }
+
+    let report = '';
+
+    differences.forEach(d => {
+      if (d.kind === 'N') {
+        report += `  - Expected: ${reportPrefix} ${_.join(d.path, ' --> ')}\n`;
+        report += `  - Promised: ${reportPrefix} [none, entry missing]\n`;
+      } else if (d.kind === 'E') {
+        report += `  - Expected: ${reportPrefix} ${_.join(d.path, ' --> ')} --> ${inspect(
+          d.rhs
+        )}\n`;
+        report += `  - Promised: ${reportPrefix} ${_.join(d.path, ' --> ')} --> ${inspect(
+          d.lhs
+        )}\n`;
+      } else if (d.kind === 'A') {
+        if (d.item.kind === 'N') {
+          report += `  - Expected: ${reportPrefix} ${_.join(
+            d.path,
+            ' --> '
+          )} --> [Array item with value: ${inspect(d.item.rhs)}] \n`;
+          report += `  - Promised: ${reportPrefix} ${_.join(
+            d.path,
+            ' --> '
+          )} --> [Array item missing]\n`;
+        }
+      }
+      report += `\n\n`;
+    });
+    return { isSubset: false, differences, report };
   }
 };

--- a/tests/contracts/integrations/rest/index_test.js
+++ b/tests/contracts/integrations/rest/index_test.js
@@ -141,7 +141,7 @@ describe('validate() in the REST APIs integration type facade', () => {
         expectation
       );
     } catch (err) {
-      assert.include(err.message, 'is not a subset of');
+      assert.include(err.message, 'Expectation broken');
     }
   });
   it("throws an error if consumer expected basePath doesn't match the producer promised basePath", async () => {
@@ -170,7 +170,9 @@ describe('validate() in the REST APIs integration type facade', () => {
         expectation
       );
     } catch (err) {
-      assert.include(err.message, "Expectation broken: '/api' != '/api/v2'");
+      assert.include(err.message, 'Expectation broken');
+      assert.include(err.message, 'basePath --> /api');
+      assert.include(err.message, 'basePath --> /api/v2');
     }
   });
   it('throws an error if consumer expected supported schemes(HTTP, HTTPS) are not a subset of the producer promised schemes', async () => {
@@ -199,7 +201,9 @@ describe('validate() in the REST APIs integration type facade', () => {
         expectation
       );
     } catch (err) {
-      assert.include(err.message, 'is not a subset of');
+      assert.include(err.message, 'Expectation broken');
+      assert.include(err.message, "Expected: schemes --> 0 --> 'https'");
+      assert.include(err.message, "Promised: schemes --> 0 --> 'http'");
     }
   });
 });

--- a/tests/fixtures/projects/broken-rest-consumer/rev-unimplemented-endpoint/contracts/expectations/good-rest-provider/rest/swagger.yml
+++ b/tests/fixtures/projects/broken-rest-consumer/rev-unimplemented-endpoint/contracts/expectations/good-rest-provider/rest/swagger.yml
@@ -42,6 +42,7 @@
       required:
         - "id"
         - "name"
+        - "inexistent-field"
       properties:
         id:
           type: "integer"


### PR DESCRIPTION
Simplified diff-report on contracts validation failures, closes #10.

**Before**
On failure, dump all of the Expectation body and Promise body and let the user figure out the difference.

**After**
Diff-based report, for example:
```
provider-client-services:contracts/ @ bfb5911a54122b89c61a877858a2b8227200962b is not valid: 

Consumer [ bpc-libs:bpc-transaction-store/contracts/ @ master ] expectations of type (rest) is broken: 
============================================================================ 
Expectation broken: 
  - Expected: paths --> /session/store/{sessionId} --> get --> produces --> 0 --> application/json;charset=UTF-8
  - Promised: paths --> /session/store/{sessionId} --> get --> produces --> 0 --> application/json;charset=LATIN-1
```